### PR TITLE
add .env to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .idea
 *.gem
 .jekyll-cache
+.env


### PR DESCRIPTION
We don't want to push secret data to git server.

as an example: 

My config.yml
```
version: '3'
services:
    jekyll-serve:
      image: jekyll/jekyll:4.2.2
      volumes:
        - '.:/srv/jekyll'
      ports:
        - 4000:4000
      environment:
        - STRAPI_TOKEN=${STRAPI_TOKEN}
      command: jekyll serve --lsi --watch --verbose --trace
```

my .env file:

```
export STRAPI_TOKEN="9exampleffff23efc78803a222afd2625fddasdf0b81df8493576c0asdfdf05ebfae430edd94da726420de3edesde9bE..."
```
