### PR TITLE
Fix dep when using Jekyll 4.2.2

### DIFF
--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -16,6 +16,7 @@ gem "minima", "~> 2.5"
 # If you have any plugins, put them here!
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
+  gem "webrick", "~> 1.7" # Ruby 3.0 doesn't include webrick anymore in 4.2.2 https://github.com/jekyll/jekyll/issues/8523
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -18,6 +18,7 @@ group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
   gem "webrick", "~> 1.7" # Ruby 3.0 doesn't include webrick anymore in 4.2.2 https://github.com/jekyll/jekyll/issues/8523
   gem "down", "~> 1.1.0" # this is for jekyll-strapi integration down dep.
+  gem "jekyll-strapi", "~> 0.1.3" # must have gem installed to make use of jekyll-strapi integration
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -17,6 +17,7 @@ gem "minima", "~> 2.5"
 group :jekyll_plugins do
   gem "jekyll-feed", "~> 0.12"
   gem "webrick", "~> 1.7" # Ruby 3.0 doesn't include webrick anymore in 4.2.2 https://github.com/jekyll/jekyll/issues/8523
+  gem "down", "~> 1.1.0" # this is for jekyll-strapi integration down dep.
 end
 
 # Windows and JRuby does not include zoneinfo files, so bundle the tzinfo-data gem

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -31,6 +31,7 @@ github_username:  strapi
 theme: minima
 plugins:
   - jekyll-feed
+  - jekyll-strapi
 
 # Exclude from processing.
 # The following items will not be processed, by default.


### PR DESCRIPTION
Ruby 3.0 doesn't include webrick anymore in 4.2.2 https://github.com/jekyll/jekyll/issues/8523