### PR TITLE
Possible to make a single collection request

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # jekyll-strapi-4
 
-This plugin is based on the [jekyll-strapi](https://github.com/strapi-community/jekyll-strapi/) plugin. 
+This plugin is based on the [jekyll-strapi](https://github.com/strapi-community/jekyll-strapi/) plugin.
 
 ![](deer-jekyll-strapi-4.png?raw=true)
 
@@ -58,6 +58,8 @@ strapi:
             # populate: "*"
             # Layout file for this collection
             layout: photo.html
+            # Single request for collection, default false
+            single_request: true
             # Generate output files or not (default: false)
             output: true
 ```
@@ -139,6 +141,19 @@ module Jekyll
   end
 end
 ```
+
+### Single request
+
+When you request for a collection it makes a collection request and collection resources request. When you have a small collection like testimonials you might not make n+1 requests but only one. In that case use single_request: true in your _config file.
+
+```yaml
+strapi:
+  collections:
+    photos:
+      single_request: true
+```
+
+You can always add to your parameters populate parameter to get additional data in your collection request.
 
 ### Permalinks
 

--- a/lib/jekyll/strapi4/collection.rb
+++ b/lib/jekyll/strapi4/collection.rb
@@ -48,9 +48,13 @@ module Jekyll
           document.type = collection_name
           document.collection = collection_name
           document.id ||= document._id
-          document_response = get_document(document.id)
-          # We will keep all the attributes in strapi_attributes
-          document.strapi_attributes = document_response['data']["attributes"]
+          if single_request?
+            document.strapi_attributes = document.attributes
+          else
+            document_response = get_document(document.id)
+            # We will keep all the attributes in strapi_attributes
+            document.strapi_attributes = document_response['data']["attributes"]
+          end
           document.url = @site.strapi_link_resolver(collection_name, document)
         end
         data.each {|x| yield(x)}
@@ -87,6 +91,10 @@ module Jekyll
         end
 
         return_params ? string : ""
+      end
+
+      def single_request?
+        @config["single_request"] == true
       end
 
       def custom_path_params

--- a/test/test_collection.rb
+++ b/test/test_collection.rb
@@ -177,6 +177,33 @@ class TestStrapiCollectionPopulate < Test::Unit::TestCase
   end
 end
 
+class TestStrapiCollectionSingleRequest < Test::Unit::TestCase
+  def setup
+    setup_collection
+  end
+
+  def test_default
+    @config = {"permalink"=>"/blog/:slug/", "layout"=>"post.html", "output"=>true}
+    @collection = Jekyll::Strapi::StrapiCollection.new(@site, @collection_name, @config)
+
+    assert_false @collection.single_request?
+  end
+
+  def test_given_false
+    @config = {"permalink"=>"/blog/:slug/", "layout"=>"post.html", "output"=>true, "single_request"=>false}
+    @collection = Jekyll::Strapi::StrapiCollection.new(@site, @collection_name, @config)
+
+    assert_false @collection.single_request?
+  end
+
+  def test_given_true
+    @config = {"permalink"=>"/blog/:slug/", "layout"=>"post.html", "output"=>true, "single_request"=>true}
+    @collection = Jekyll::Strapi::StrapiCollection.new(@site, @collection_name, @config)
+
+    assert_true @collection.single_request?
+  end
+end
+
 class TestStrapiCollectionPathParams < Test::Unit::TestCase
   def setup
     setup_collection


### PR DESCRIPTION
Making n+1 requests for small collections takes so long times - here is fix to do only one request when defined in config.